### PR TITLE
Rerelease 0.14.3 with correct dependency constraints

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gluonts" %}
-{% set version = "0.15.1" %}
+{% set version = "0.14.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/gluonts-{{ version }}.tar.gz
-  sha256: af1a12b9f22f8db071f31da518a9c61f1539b0036d857826c88091032bb9a845
+  sha256: 955602c7853fc4b252451360848f58542df830fe89c10d38473c4d2000bd9993
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -21,9 +21,9 @@ requirements:
   run:
     - python >=3.7
     - numpy >=1.16,<2.dev0
-    - pandas >=1.0,<2.2.0
+    - pandas >=1.0,<3.dev0
     - pydantic >=1.7,<3.dev0
-    - tqdm >4.23,<5.dev0
+    - tqdm >=4.23,<5.dev0
     - toolz >=0.10,<1.dev0
     - typing-extensions >=4.0,<5.dev0
     - pytorch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/gluonts-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/gluonts-{{ version }}.tar.gz
   sha256: 955602c7853fc4b252451360848f58542df830fe89c10d38473c4d2000bd9993
 
 build:
@@ -18,6 +18,7 @@ requirements:
   host:
     - python >=3.7
     - pip
+    - setuptools
   run:
     - python >=3.7
     - numpy >=1.16,<2.dev0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

[Per the public repo](https://github.com/awslabs/gluonts/blob/v0.14.3/requirements/requirements.txt#L3C1-L3C17), gluonts 0.14.3 supports pydantic>=1.7,<3
However, the conda-forge gluonts 0.14.3 has a constraint pydantic >=1.7,<2.dev0
https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fnoarch%2Fgluonts-0.14.3-pyhd8ed1ab_0.conda

Taking 0.14.3 recipe (https://github.com/conda-forge/gluonts-feedstock/

<!--
Please add any other relevant info below:
-->
